### PR TITLE
Properly re-add the watchers_sup to the dispcount_sup on restart

### DIFF
--- a/src/dispcount_serv.erl
+++ b/src/dispcount_serv.erl
@@ -74,7 +74,20 @@ handle_cast(_Cast, State) ->
     {noreply, State}.
 
 handle_info(continue_init, {Parent, ChildSpec, Conf}) ->
-    {ok, Sup} = supervisor:start_child(Parent, ChildSpec),
+    Sup = case supervisor:start_child(Parent, ChildSpec) of
+              {error, {already_started, OldPid}} ->
+                  %% get rid of old supervisor with stale references in it
+                  ok = supervisor:terminate_child(Parent, watchers_sup),
+                  ok = supervisor:delete_child(Parent, watchers_sup),
+                  Ref = erlang:monitor(process, OldPid),
+                  receive {'DOWN', Ref, process, OldPid, _} ->
+                              ok
+                  end,
+                  {ok, S} = supervisor:start_child(Parent, ChildSpec),
+                  S;
+              {ok, S} ->
+                  S
+          end,
     ok = start_watchers(Sup, Conf),
     {noreply, Conf};
 handle_info(_Info, State) ->


### PR DESCRIPTION
If the dispcount_serv dies (or is restarted because of too many worker
failures), the addition of the watchers_sup to the supervisor tree may
fail because an old child spec (with invalid references) is still
installed. This change ensures that if an old supervisor is still
installed it is terminated and deleted before adding a new one.