### PR TITLE
Add dispcount:transaction/2 for running funs in watcher context

### DIFF
--- a/src/dispcount.erl
+++ b/src/dispcount.erl
@@ -2,11 +2,14 @@
 -behaviour(application).
 -export([start/2,stop/1]).
 -export([start_dispatch/3, stop_dispatch/1,
-         dispatcher_info/1, checkout/1, checkout/2, checkin/3]).
+         dispatcher_info/1, checkout/1, checkout/2, transaction/2, checkin/3]).
 
 -callback init(Args::[any()]) -> {ok, CallbackState::any()}.
 -callback checkout(From::pid(), CallbackState::any()) -> {ok, Resource::any(), NewCallbackState::any()} |
                                     {error, Reason::any(), NewCallbackState::any()} |
+                                    {stop, Reason::any(), NewCallbackState::any()}.
+-callback transaction(From::pid(), Fun::function(), CallbackState::any()) -> ok |
+                                    {ok, NewCallbackState::any()} |
                                     {stop, Reason::any(), NewCallbackState::any()}.
 -callback checkin(Resource::any(), CallbackState::any()) -> {ok, NewCallbackState::any()} |
                                    {ignore, CallbackState::any()} |
@@ -48,6 +51,10 @@ checkout(Info) ->
 -spec checkout(term(), timeout()) -> {ok, term(), term()} | {error, term()}.
 checkout(Info, Timeout) ->
     dispcount_watcher:checkout(Info, Timeout).
+
+-spec transaction(term(), function()) -> ok.
+transaction(Info, Fun) ->
+    dispcount_watcher:transaction(Info, Fun).
 
 -spec checkin(term(), term(), term()) -> ok.
 checkin(Info, CheckinRef, Resource) ->


### PR DESCRIPTION
To avoid unnecessary calls and waiting for responses allow for a fun to
be passed as a transaction that can be run by the watcher. As soon as
the fun completes, the watcher is marked as free again without
intervention by the calling process. This should improve throughput for
use cases where the caller having direct access to the resource is
not necessary.

This still needs tests, but I have it working in the field.