### PR TITLE
Give proper return type definition for dispcount:start_dispatch/3.

### DIFF
--- a/src/dispcount.erl
+++ b/src/dispcount.erl
@@ -29,7 +29,7 @@ stop(_State) ->
 stop_dispatch(Name) ->
     dispcount_supersup:stop_dispatch(Name).
 
--spec start_dispatch(Name::atom(), {module(), _}, term()) -> ok | already_defined.
+-spec start_dispatch(Name::atom(), {module(), _}, term()) -> ok | already_started.
 start_dispatch(Name, Mod={M,_A}, DispatchOpts) when is_atom(M) ->
     Res = dispcount_supersup:start_dispatch(Name, Mod, DispatchOpts),
     %% wait for all tables to be there. A bit messy, but it can be done:

--- a/src/dispcount_supersup.erl
+++ b/src/dispcount_supersup.erl
@@ -9,7 +9,7 @@
 start_link() ->
     supervisor:start_link({local,?MODULE}, ?MODULE, []).
 
--spec start_dispatch(Name::atom(), {module(),[term()]}, Opts::[term()]) -> ok.
+-spec start_dispatch(Name::atom(), {module(),[term()]}, Opts::[term()]) -> ok | already_started.
 start_dispatch(Name, Mod, Opts) ->
     case supervisor:start_child(?MODULE, [Name, Mod, Opts]) of
         {ok, _} -> ok;


### PR DESCRIPTION
Hi, I hit a dialyzer warning because the `dispcount_supersup:start_dispatch/3` return type is not defined properly.

The scenario as follows.

```erlang
start_dispatch() ->
    Res = dispcount:start_dispatch(some_key, {some_dispatch_h, []}, []),
    case Res of
        ok -> ok;
        already_started -> ok
    end.
```
When I run the dialyzer I will get `The pattern 'already_started' can never match the type 'ok'`.

Please review it. Thank you!